### PR TITLE
feature : 하나의 기기에서 다중 로그인 알람 처리 구현

### DIFF
--- a/src/main/java/com/sloth/api/login/oauth/controller/OauthLoginController.java
+++ b/src/main/java/com/sloth/api/login/oauth/controller/OauthLoginController.java
@@ -14,12 +14,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 @Slf4j
 @RestController
@@ -37,7 +39,7 @@ public class OauthLoginController {
     // TODO param 정보 입력
     //@ApiImplicitParam(name = "acceessToken", dataType = "body", required = true, dataTypeClass = com.sloth.api.oauth.dto.OauthRequestDto.class),
     //@ApiImplicitParam(name = "socialType", dataType = "body", required = true, dataTypeClass = com.sloth.api.oauth.dto.OauthRequestDto.class)
-    public ResponseEntity<ResponseJwtTokenDto> login(@RequestBody OauthRequestDto oauthRequestDto, HttpServletRequest httpServletRequest) {
+    public ResponseEntity<ResponseJwtTokenDto> login(@Valid @RequestBody OauthRequestDto oauthRequestDto, HttpServletRequest httpServletRequest) {
 
         log.info("oauth login start");
 
@@ -48,11 +50,10 @@ public class OauthLoginController {
         }
 
         if(!SocialType.isSocialType(oauthRequestDto.getSocialType()) || oauthRequestDto.getSocialType().equals(SocialType.FORM.name())) {
-            throw new InvalidParameterException("잘못된 소셜 타입입니다. 'GOOGLE', 'KAKAO', 'APPLE' 중에 입력해주세요");
+            throw new InvalidParameterException("잘못된 소셜 타입입니다. 'GOOGLE', 'KAKAO' 중에 입력해주세요");
         }
 
-        SocialType socialType = SocialType.from(oauthRequestDto.getSocialType());
-        ResponseJwtTokenDto responseJwtTokenDto = oauthLoginService.loginOauth(accessToken, socialType);
+        ResponseJwtTokenDto responseJwtTokenDto = oauthLoginService.loginOauth(accessToken, oauthRequestDto);
 
         log.info("oauth login end");
 

--- a/src/main/java/com/sloth/api/login/oauth/dto/OauthRequestDto.java
+++ b/src/main/java/com/sloth/api/login/oauth/dto/OauthRequestDto.java
@@ -12,4 +12,7 @@ public class OauthRequestDto {
     @ApiModelProperty(value = "소셜 로그인 타입(GOOGLE, KAKAO, APPLE)")
     private String socialType;
 
+    @ApiModelProperty(value = "fcm token")
+    private String fcmToken;
+
 }

--- a/src/main/java/com/sloth/api/login/oauth/service/OauthLoginService.java
+++ b/src/main/java/com/sloth/api/login/oauth/service/OauthLoginService.java
@@ -57,15 +57,16 @@ public class OauthLoginService {
         // 회원가입
         Boolean isNewMember = false;
         Optional<Member> optionalMember = memberService.getOptionalMember(oAuthAttributes.getEmail());
+        Member loginMember;
         if (optionalMember.isEmpty()) { // 기존 회원이 아닐 때
             Member oauthMember = memberService.createOauthMember(oAuthAttributes);
-            oauthMember = memberService.saveMember(oauthMember, tokenDto);
+            loginMember = memberService.saveMember(oauthMember, tokenDto);
             isNewMember = true;
-            deleteFcmTokenAndSaveNewFcmToken(oauthRequestDto, oauthMember);
         } else {
             memberService.saveRefreshToken(optionalMember.get(), tokenDto); // 기존 회원일 때
-            deleteFcmTokenAndSaveNewFcmToken(oauthRequestDto, optionalMember.get());
+            loginMember = optionalMember.get();
         }
+        deleteFcmTokenAndSaveNewFcmToken(oauthRequestDto, loginMember);
 
         ResponseJwtTokenDto responseJwtTokenDto = modelMapper.map(tokenDto, ResponseJwtTokenDto.class);
         responseJwtTokenDto.setIsNewMember(isNewMember);

--- a/src/main/java/com/sloth/api/login/oauth/service/OauthLoginService.java
+++ b/src/main/java/com/sloth/api/login/oauth/service/OauthLoginService.java
@@ -1,8 +1,11 @@
 package com.sloth.api.login.oauth.service;
 
 import com.sloth.api.login.dto.ResponseJwtTokenDto;
+import com.sloth.api.login.oauth.dto.OauthRequestDto;
 import com.sloth.api.login.oauth.social.service.SocialApiSerivce;
 import com.sloth.api.login.oauth.social.service.SocialApiServiceFactory;
+import com.sloth.domain.fcm.entity.FcmToken;
+import com.sloth.domain.fcm.service.FcmTokenService;
 import com.sloth.domain.member.Member;
 import com.sloth.domain.member.constant.SocialType;
 import com.sloth.domain.member.service.MemberService;
@@ -15,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import javax.transaction.Transactional;
 import java.util.Optional;
@@ -30,14 +34,17 @@ public class OauthLoginService {
     private final PasswordEncoder passwordEncoder;
     private final MailService mailService;
     private final ModelMapper modelMapper;
+    private final FcmTokenService fcmTokenService;
 
     /**
      * OAuth 로그인
      * @param accessToken
-     * @param socialType
+     * @param oauthRequestDto
      * @return
      */
-    public ResponseJwtTokenDto loginOauth(String accessToken, SocialType socialType) {
+    public ResponseJwtTokenDto loginOauth(String accessToken, OauthRequestDto oauthRequestDto) {
+
+        SocialType socialType = SocialType.from(oauthRequestDto.getSocialType());
 
         // 소셜 회원 정보 조회
         OAuthAttributes oAuthAttributes = getSocialUserInfo(accessToken, socialType);
@@ -52,14 +59,32 @@ public class OauthLoginService {
         Optional<Member> optionalMember = memberService.getOptionalMember(oAuthAttributes.getEmail());
         if (optionalMember.isEmpty()) { // 기존 회원이 아닐 때
             Member oauthMember = memberService.createOauthMember(oAuthAttributes);
-            memberService.saveMember(oauthMember, tokenDto);
+            oauthMember = memberService.saveMember(oauthMember, tokenDto);
             isNewMember = true;
-        } else memberService.saveRefreshToken(optionalMember.get(), tokenDto); // 기존 회원일 때
+            deleteFcmTokenAndSaveNewFcmToken(oauthRequestDto, oauthMember);
+        } else {
+            memberService.saveRefreshToken(optionalMember.get(), tokenDto); // 기존 회원일 때
+            deleteFcmTokenAndSaveNewFcmToken(oauthRequestDto, optionalMember.get());
+        }
 
         ResponseJwtTokenDto responseJwtTokenDto = modelMapper.map(tokenDto, ResponseJwtTokenDto.class);
         responseJwtTokenDto.setIsNewMember(isNewMember);
 
         return responseJwtTokenDto;
+    }
+
+    /**
+     * 기존 fcmToken 삭제 처리 (하나의 기기에 여러계정 로그인 처리)
+     * @param oauthRequestDto
+     * @param member
+     */
+    private void deleteFcmTokenAndSaveNewFcmToken(OauthRequestDto oauthRequestDto, Member member) {
+        String fcmToken = oauthRequestDto.getFcmToken();
+        if(StringUtils.hasText(fcmToken)) {
+            fcmTokenService.deleteFcmToken(fcmToken);
+            FcmToken newFcmToken = FcmToken.createFcmToken(member, fcmToken, null);
+            fcmTokenService.saveFcmToken(newFcmToken);
+        }
     }
 
     private OAuthAttributes getSocialUserInfo(String accessToken, SocialType socialType) {

--- a/src/main/java/com/sloth/api/logout/controller/LogoutController.java
+++ b/src/main/java/com/sloth/api/logout/controller/LogoutController.java
@@ -22,9 +22,9 @@ public class LogoutController {
 
     @PostMapping(value = "/logout")
     @Operation(summary = "로그아웃", description = "로그아웃 처리 시 db에 저장된 refresh token 만료 처리")
-    public ResponseEntity<String> logout(@RequestHeader(value="Authorization") String accessToken) {
+    public ResponseEntity<String> logout(@RequestHeader(value="Authorization") String accessToken, String fcmToken) {
         String email  = tokenProvider.getEmail(accessToken);
-        logoutService.logout(email, LocalDateTime.now());
+        logoutService.logout(email, LocalDateTime.now(), fcmToken);
         return ResponseEntity.ok().body("logout success");
     }
 

--- a/src/main/java/com/sloth/api/logout/service/LogoutService.java
+++ b/src/main/java/com/sloth/api/logout/service/LogoutService.java
@@ -1,5 +1,7 @@
 package com.sloth.api.logout.service;
 
+import com.sloth.domain.fcm.entity.FcmToken;
+import com.sloth.domain.fcm.service.FcmTokenService;
 import com.sloth.domain.member.Member;
 import com.sloth.domain.member.service.MemberService;
 import com.sloth.domain.memberToken.MemberToken;
@@ -8,6 +10,7 @@ import com.sloth.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
 
@@ -18,11 +21,16 @@ public class LogoutService {
 
     private final MemberService memberService;
     private final MemberTokenService memberTokenService;
+    private final FcmTokenService fcmTokenService;
 
-    public void logout(String email, LocalDateTime now) {
+    public void logout(String email, LocalDateTime now, String fcmToken) {
         Member member = memberService.findByEmail(email);
         MemberToken memberToken = memberTokenService.findMemberTokenByMemberId(member.getMemberId());
         memberToken.expireToken(now);
+
+        if(StringUtils.hasText(fcmToken)) {
+            fcmTokenService.deleteFcmToken(fcmToken);
+        }
     }
 
 }

--- a/src/main/java/com/sloth/domain/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/sloth/domain/fcm/repository/FcmTokenRepository.java
@@ -3,6 +3,9 @@ package com.sloth.domain.fcm.repository;
 import com.sloth.domain.fcm.entity.FcmToken;
 import com.sloth.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -13,5 +16,9 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
     FcmToken findByMemberAndDeviceId(Member member, String deviceId);
 
     List<FcmToken> findByMember(Member member);
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from FcmToken ft where ft.fcmToken = :fcmToken")
+    void deleteByFcmToken(@Param("fcmToken") String fcmToken);
 
 }

--- a/src/main/java/com/sloth/domain/fcm/service/FcmTokenService.java
+++ b/src/main/java/com/sloth/domain/fcm/service/FcmTokenService.java
@@ -30,4 +30,8 @@ public class FcmTokenService {
         return fcmTokenRepository.findByMember(member);
     }
 
+    public void deleteFcmToken(String fcmToken) {
+        fcmTokenRepository.deleteByFcmToken(fcmToken);
+    }
+
 }

--- a/src/test/java/com/sloth/api/logout/controller/LogoutControllerTest.java
+++ b/src/test/java/com/sloth/api/logout/controller/LogoutControllerTest.java
@@ -51,7 +51,7 @@ class LogoutControllerTest extends NewBaseApiController {
         // given
         String email = "test@test.com";
         final String accessToken = "accessToken";
-        doNothing().when(logoutService).logout(eq(email), any());
+        doNothing().when(logoutService).logout(eq(email), any(), any());
         when(tokenProvider.getEmail(accessToken)).thenReturn(email);
 
         // when

--- a/src/test/java/com/sloth/api/logout/service/LogoutServiceTest.java
+++ b/src/test/java/com/sloth/api/logout/service/LogoutServiceTest.java
@@ -2,6 +2,7 @@ package com.sloth.api.logout.service;
 
 import com.sloth.api.logout.service.LogoutService;
 import com.sloth.creator.MemberCreator;
+import com.sloth.domain.fcm.service.FcmTokenService;
 import com.sloth.domain.member.Member;
 import com.sloth.domain.member.service.MemberService;
 import com.sloth.domain.memberToken.MemberToken;
@@ -28,21 +29,26 @@ class LogoutServiceTest extends BaseServiceTest {
     @Mock
     private MemberTokenService memberTokenService;
 
+    @Mock
+    private FcmTokenService fcmTokenService;
+
     @Test
     @DisplayName("로그아웃 테스트")
     void logoutTest() {
 
         // given
         String email = "test@test.com";
+        String fcmToken = "fcmTokenTest";
         LocalDateTime tokenExpirationTime = LocalDateTime.of(2022,1,1,3,5,0);
         Member member = MemberCreator.createMember(1L, email);
         MemberToken memberToken = MemberToken.createMemberToken(member, "abcabcabc", tokenExpirationTime);
         when(memberService.findByEmail(email)).thenReturn(member);
         when(memberTokenService.findMemberTokenByMemberId(member.getMemberId())).thenReturn(memberToken);
+        doNothing().when(fcmTokenService).deleteFcmToken(fcmToken);
 
         // when
         LocalDateTime now = LocalDateTime.of(2021,12,20,3,5,0);
-        logoutService.logout(email, now);
+        logoutService.logout(email, now, fcmToken);
 
         // then
         Assertions.assertThat(memberToken.getTokenExpirationTime()).isEqualTo(now);


### PR DESCRIPTION
구현 내용 

1. 로그인 시 fcmToken을 받아서 해당 fcmToken 모두 삭제 및 fcmToken 신규로 생성하여 저장 (fcmToken당 1개의 로그인 보장)
2. 로그아웃 시 fcmToken을 받아서 fcmToken 모두 삭제 처리. 로그아웃시 해당 계정의 알림은 전송X